### PR TITLE
better way of handling unexpected responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,12 @@ with the response and let the engine run again.
 ```java
 try {
     state = engine.updateStateWithResponse(state, response);
+    snippets = engine.startConversationFromState(state);
+} catch (UnexpectedResponseException e) {
+    // the current node is not a QUESTION
 } catch (UnmatchedResponseException e) {
-
+    // no outbound edges matched the response
 }
-snippets = engine.startConversationFromState(state);
 ```
 
 ## Conversation State

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.conversationkit</groupId>
     <artifactId>conversation-kit</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <name>conversation-kit core</name>
     <description>A directed graph model for conversational UIs.</description>
     <url>http://conversationkit.com</url>

--- a/src/main/java/com/conversationkit/impl/DirectedConversationEngine.java
+++ b/src/main/java/com/conversationkit/impl/DirectedConversationEngine.java
@@ -31,6 +31,7 @@ import com.conversationkit.model.IConversationSnippet;
 import com.conversationkit.model.IConversationState;
 import com.conversationkit.model.SnippetContentType;
 import com.conversationkit.model.SnippetType;
+import com.conversationkit.model.UnexpectedResponseException;
 import com.conversationkit.model.UnmatchedResponseException;
 import java.util.ArrayList;
 import java.util.List;
@@ -79,7 +80,7 @@ public class DirectedConversationEngine<S extends IConversationState> implements
     }
 
     @Override
-    public S updateStateWithResponse(S state, String response) throws UnmatchedResponseException {
+    public S updateStateWithResponse(S state, String response) throws UnmatchedResponseException, UnexpectedResponseException {
         IConversationNode<S> currentSnippet = nodeIndex.getNodeAtIndex(state.getCurrentNodeId());
 
         if (currentSnippet.getType() == SnippetType.QUESTION) {
@@ -102,9 +103,7 @@ public class DirectedConversationEngine<S extends IConversationState> implements
                 throw new UnmatchedResponseException();
             }
         } else {
-            logger.warning("adding response to conversation but current node is not a QUESTION");
-            state.setMostRecentResponse(response);
-            throw new UnmatchedResponseException();
+            throw new UnexpectedResponseException(String.format("received response '%s' to node %d which is not a QUESTION",response,state.getCurrentNodeId()));
         }
 
         return state;

--- a/src/main/java/com/conversationkit/impl/edge/AffirmativeEdge.java
+++ b/src/main/java/com/conversationkit/impl/edge/AffirmativeEdge.java
@@ -32,7 +32,7 @@ import com.conversationkit.model.IConversationState;
  */
 public class AffirmativeEdge <S extends IConversationState> extends RegexEdge<S> {
 
-    private static final String YES = "\\byes\\b|\\byep\\b|\\byeah\\b|\\bsome\\b|\\a little\\b|\\ba bit\\b";
+    private static final String YES = "\\bk\\b|\\bok\\b|\\byes\\b|\\byep\\b|\\byeah\\b|\\bsome\\b|\\a little\\b|\\ba bit\\b";
     
     public AffirmativeEdge(String stateKey, Object stateValue, IConversationNode<S> endNode) {
         super(YES,stateKey,stateValue,endNode);

--- a/src/main/java/com/conversationkit/model/IConversationEngine.java
+++ b/src/main/java/com/conversationkit/model/IConversationEngine.java
@@ -36,6 +36,27 @@ import java.util.List;
  * for the current user
  */
 public interface IConversationEngine<S extends IConversationState> {
+    /**
+     * Follows the conversation graph starting at the current node defined by the state
+     * parameter.  Implementation details may vary, but generally this method will
+     * return all the <code>IConversationSnippet</code>s along the graph until
+     * it reaches a node that requires a response from the user. The <code>state</code>
+     * is updated to reflect the new <code>currentNodeId</code>.
+     * 
+     * @param state initial state
+     * @return IConversationSnippets to display to the user
+     */
     public Iterable<IConversationSnippet> startConversationFromState(S state);
-    public S updateStateWithResponse(S state, String response) throws UnmatchedResponseException;
+    
+    /**
+     * Updates the conversation with a response from the user and advances the 
+     * currentNodeId if a matching edge is found.
+     * 
+     * @param state the current IConversationState
+     * @param response the user's response
+     * @return the updated state
+     * @throws UnmatchedResponseException if no outbound edges from the current node match the response
+     * @throws UnexpectedResponseException if the conversation is in a state where it is not expecting a response (e.g. the current node is not a QUESTION)
+     */
+    public S updateStateWithResponse(S state, String response) throws UnmatchedResponseException, UnexpectedResponseException;
 }

--- a/src/main/java/com/conversationkit/model/UnexpectedResponseException.java
+++ b/src/main/java/com/conversationkit/model/UnexpectedResponseException.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2016 Synclab Consulting LLC.
+ * Copyright 2017 Synclab Consulting LLC.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,29 +24,30 @@
 package com.conversationkit.model;
 
 /**
- * An <code>UnmatchedResponseException</code> is thrown when 
- * the <code>IConversationEngine</code>
- * implementation cannot match the response to any outbound 
- * <code>IConversationEdge</code>.
+ * An <code>UnexpectedResponseException</code> is thrown when the 
+ * <code>IConversationEngine</code> is not expecting a response from the user.
+ * Most frequently this would happen when the <code>IConversationState</code>
+ * reflects that the current node is a <code>STATEMENT</code>, not a 
+ * <code>QUESTION</code>.
  * 
  * @author pdtyreus
  */
-public class UnmatchedResponseException extends Exception {
+public class UnexpectedResponseException extends Exception {
 
     /**
-     * Creates a new instance of <code>UnmatchedResponseException</code> without
-     * detail message.
+     * Creates a new instance of <code>UnexpectedResponseException</code>
+     * without detail message.
      */
-    public UnmatchedResponseException() {
+    public UnexpectedResponseException() {
     }
 
     /**
-     * Constructs an instance of <code>UnmatchedResponseException</code> with
+     * Constructs an instance of <code>UnexpectedResponseException</code> with
      * the specified detail message.
      *
      * @param msg the detail message.
      */
-    public UnmatchedResponseException(String msg) {
+    public UnexpectedResponseException(String msg) {
         super(msg);
     }
 }

--- a/src/test/java/com/conversationkit/impl/ConversationGraphTest.java
+++ b/src/test/java/com/conversationkit/impl/ConversationGraphTest.java
@@ -28,6 +28,7 @@ import com.conversationkit.builder.JsonGraphBuilder;
 import com.conversationkit.model.IConversationSnippet;
 import com.conversationkit.model.SnippetContentType;
 import com.conversationkit.model.SnippetType;
+import com.conversationkit.model.UnexpectedResponseException;
 import com.conversationkit.model.UnmatchedResponseException;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -73,7 +74,7 @@ public class ConversationGraphTest extends TestCase {
         OutputUtil.formatResponse(formatter, response);
         try {
             tree.updateStateWithResponse(state, response);
-        } catch (UnmatchedResponseException e) {
+        } catch (UnmatchedResponseException | UnexpectedResponseException e) {
             fail(e.toString());
         }
         nodes = tree.startConversationFromState(state);
@@ -107,6 +108,8 @@ public class ConversationGraphTest extends TestCase {
                 }
                 
             }, state);
+        } catch (UnexpectedResponseException e) {
+            fail(e.toString());
         }
         nodes = tree.startConversationFromState(state);
         for (IConversationSnippet node : nodes) {
@@ -118,7 +121,7 @@ public class ConversationGraphTest extends TestCase {
 
         try {
             tree.updateStateWithResponse(state, response);
-        } catch (UnmatchedResponseException e) {
+        } catch (UnmatchedResponseException | UnexpectedResponseException e) {
             fail(e.toString());
         }
         nodes = tree.startConversationFromState(state);
@@ -131,7 +134,7 @@ public class ConversationGraphTest extends TestCase {
 
         try {
             tree.updateStateWithResponse(state, response);
-        } catch (UnmatchedResponseException e) {
+        } catch (UnmatchedResponseException | UnexpectedResponseException e) {
             fail(e.toString());
         }
         nodes = tree.startConversationFromState(state);

--- a/src/test/java/com/conversationkit/impl/DialogTreeTest.java
+++ b/src/test/java/com/conversationkit/impl/DialogTreeTest.java
@@ -25,6 +25,7 @@ package com.conversationkit.impl;
 
 import com.conversationkit.impl.DirectedConversationEngine;
 import com.conversationkit.model.IConversationSnippet;
+import com.conversationkit.model.UnexpectedResponseException;
 import com.conversationkit.model.UnmatchedResponseException;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -86,7 +87,7 @@ public class DialogTreeTest extends TestCase {
         OutputUtil.formatResponse(formatter, response);
         try {
             tree.updateStateWithResponse(state, response);
-        } catch (UnmatchedResponseException e) {
+        } catch (UnmatchedResponseException | UnexpectedResponseException e) {
             fail(e.toString());
         } 
         nodes = tree.startConversationFromState(state);
@@ -129,7 +130,7 @@ public class DialogTreeTest extends TestCase {
         OutputUtil.formatResponse(formatter, response);
         try {
             tree.updateStateWithResponse(state, response);
-        } catch (UnmatchedResponseException e) {
+        } catch (UnmatchedResponseException | UnexpectedResponseException e) {
             fail(e.toString());
         } 
         nodes = tree.startConversationFromState(state);
@@ -160,7 +161,7 @@ public class DialogTreeTest extends TestCase {
 
         try {
             tree.updateStateWithResponse(state, response);
-        } catch (UnmatchedResponseException e) {
+        } catch (UnmatchedResponseException | UnexpectedResponseException e) {
             fail(e.toString());
         } 
         nodes = tree.startConversationFromState(state);
@@ -175,7 +176,7 @@ public class DialogTreeTest extends TestCase {
         OutputUtil.formatResponse(formatter, response);
         try {
             tree.updateStateWithResponse(state, response);
-        } catch (UnmatchedResponseException e) {
+        } catch (UnmatchedResponseException | UnexpectedResponseException e) {
             fail(e.toString());
         } 
         nodes = tree.startConversationFromState(state);
@@ -185,6 +186,17 @@ public class DialogTreeTest extends TestCase {
         }
 
         assertEquals(3, state.getCurrentNodeId());
+        
+        response = "You still there?";
+        OutputUtil.formatResponse(formatter, response);
+        try {
+            tree.updateStateWithResponse(state, response);
+            fail("Should have thrown an UnexpectedResponseException");
+        } catch (UnmatchedResponseException e) {
+            fail(e.toString());
+        } catch (UnexpectedResponseException e) {
+            //expected
+        }
 
         logger.info(convo.toString());
     }


### PR DESCRIPTION
conversations can now throw either `UnmatchedResponseException` and `UnexpectedResponseException` to give better control over conversation flow.

This is a breaking change where the conversation engine can throw a new exception type `UnexpectedResponseException` in addition to `UnmatchedResponseException`. The idea is to be able to differentiate between a response to a question that was not understood and a user starting a conversation when the bot is not expecting a response.